### PR TITLE
Update DLite and specify max major version for NumPy

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,10 @@ python -m pip install -U pip
 pip install -U -e .
 ```
 
+> **Important**: If using this service locally alongside [DLite](https://github.com/SINTEF/dlite), it is important to note that issues may occur if [NumPy](https://numpy.org) v2 is used.
+> There is no known issues with NumPy v1.
+> This is a registered issue found for DLite v0.5.16.
+
 ## Run the service
 
 The service requires a MongoDB server to be running, and the service needs to be able to connect to it.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,7 +37,8 @@ dependencies = [
 [project.optional-dependencies]
 testing = [
     "cryptography ~=42.0",
-    "dlite-python ~=0.5.1; python_version < '3.12'",
+    "dlite-python ~=0.5.16",
+    "numpy <2",  # requirement for DLite v0.5.16, which does not support NumPy v2
     "pytest ~=8.0",
     "pytest-cov ~=5.0",
     "pytest-httpx ~=0.30.0",

--- a/tests/service/routers/test_entities_get.py
+++ b/tests/service/routers/test_entities_get.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations
 
-import sys
 from typing import TYPE_CHECKING
 
 import pytest
@@ -39,10 +38,6 @@ def test_get_entity(
     assert resolved_entity == parameterized_entity.entity, json.dumps(resolved_entity, indent=2)
 
 
-@pytest.mark.skipif(
-    sys.version_info >= (3, 12),
-    reason="DLite-Python does not support Python 3.12+.",
-)
 def test_get_entity_instance(
     parameterized_entity: ParameterizeGetEntities,
     client: ClientFixture,


### PR DESCRIPTION
As of v0.5.16, DLite now supports Python 3.12, but not NumPy v2

Ensure NumPy v1 is installed if DLite is installed.

Add a note about this to the README.