### PR TITLE
Fix test user creation in MongoDB

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -21,5 +21,10 @@ updates:
     - skip_changelog
   groups:
     pyproject:
+      applies-to: "version-updates"
+      patterns:
+        - "*"
+    pyproject-security:
+      applies-to: "security-updates"
       patterns:
         - "*"

--- a/.github/docker_init/create_x509_user.js
+++ b/.github/docker_init/create_x509_user.js
@@ -7,17 +7,8 @@ db.getSiblingDB("$external").runCommand(
     }
 )
 
-db.createUser(
-    {
-        user: "root",
-        pwd: "root",
-        roles: [
-            { role: "root", db: "admin" }
-        ]
-    }
-)
-
-db.createUser(
+// Create the guest user on the admin database
+db.getSiblingDB("admin").createUser(
     {
         user: "guest",
         pwd: "guest",

--- a/.github/workflows/ci_tests.yml
+++ b/.github/workflows/ci_tests.yml
@@ -54,7 +54,6 @@ jobs:
       ENTITIES_SERVICE_CA_FILE: docker_security/test-ca.pem
       ENTITIES_SERVICE_EXTERNAL_OAUTH: 0
       # These are used in the Dockerfile as well as in pytest
-      ENTITIES_SERVICE_HOST: localhost
       ENTITIES_SERVICE_PORT: 8000
       STOP_TIME: 3
 

--- a/.github/workflows/ci_tests.yml
+++ b/.github/workflows/ci_tests.yml
@@ -61,10 +61,10 @@ jobs:
       - name: Checkout ${{ github.repository }}
         uses: actions/checkout@v4
 
-      - name: Setup Python 3.10
+      - name: Setup Python 3.12
         uses: actions/setup-python@v5
         with:
-          python-version: "3.10"
+          python-version: "3.12"
 
       - name: Run MongoDB
         run: |
@@ -178,7 +178,7 @@ jobs:
           flags: docker
         env:
           OS: ubuntu-latest
-          PYTHON: '3.10'
+          PYTHON: '3.12'
 
   pytest:
     runs-on: ubuntu-latest

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.10-slim as base
+FROM python:3.12-slim AS base
 
 WORKDIR /app
 
@@ -14,7 +14,7 @@ RUN apt-get update && \
   pip install -U -e .[server]
 
 ## DEVELOPMENT target
-FROM base as development
+FROM base AS development
 
 # Copy over the self-signed certificates for development
 COPY docker_security docker_security/
@@ -28,7 +28,7 @@ ENV ENTITIES_SERVICE_DEBUG=1
 ENTRYPOINT gunicorn --bind "0.0.0.0:${PORT}" --log-level debug --workers 1 --worker-class entities_service.uvicorn.UvicornWorker --reload entities_service.main:APP
 
 ## PRODUCTION target
-FROM base as production
+FROM base AS production
 
 ENV PORT=80
 EXPOSE ${PORT}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,4 +1,4 @@
-version: "3"
+name: entities_service
 
 services:
   entities_service:
@@ -22,7 +22,7 @@ services:
       - entities_service_net
     volumes:
       - "${PWD}:/app"
-    user: "1000:1000"
+    stop_grace_period: 1s
 
   mongodb:
     image: mongo:7
@@ -47,6 +47,26 @@ services:
       interval: 10s
       timeout: 5s
       retries: 5
+
+  mongodb_gui:
+    image: mongo-express:1
+    restart: always
+    ports:
+      - "${MONGO_GUI_PORT:-8081}:8081"
+    environment:
+      ME_CONFIG_MONGODB_SERVER: mongodb
+      ME_CONFIG_MONGODB_PORT: 27017
+      ME_CONFIG_MONGODB_ENABLE_ADMIN: "true"
+      ME_CONFIG_MONGODB_ADMINUSERNAME: root
+      ME_CONFIG_MONGODB_ADMINPASSWORD: root
+      ME_CONFIG_BASICAUTH_USERNAME: admin
+      ME_CONFIG_BASICAUTH_PASSWORD: admin
+    networks:
+      - entities_service_net
+    depends_on:
+      mongodb:
+        condition: service_healthy
+        restart: true
 
 networks:
   entities_service_net:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,7 +8,6 @@ services:
     ports:
       - "${ENTITIES_SERVICE_PORT:-8000}:80"
     environment:
-      ENTITIES_SERVICE_BASE_URL: "${ENTITIES_SERVICE_HOST:-http://onto-ns.com/meta}"
       ENTITIES_SERVICE_BACKEND: mongodb
       ENTITIES_SERVICE_MONGO_URI: "mongodb://mongodb:27017"
       ENTITIES_SERVICE_X509_CERTIFICATE_FILE: "docker_security/test-client.pem"
@@ -22,6 +21,7 @@ services:
       - entities_service_net
     volumes:
       - "${PWD}:/app"
+    user: "1000:1000"  # To ensure files created in the container are owned by the host user
     stop_grace_period: 1s
 
   mongodb:

--- a/entities_service/main.py
+++ b/entities_service/main.py
@@ -56,11 +56,7 @@ async def lifespan(app: FastAPI):
             if credentials.scheme != "Bearer":
                 raise credentials_exception
 
-            if credentials.credentials != (
-                "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiJyb290IiwiaXNzIjoiaHR0cDovL29udG8tbnMuY29t"
-                "L21ldGEiLCJleHAiOjE3MDYxOTI1OTAsImNsaWVudF9pZCI6Imh0dHA6Ly9vbnRvLW5zLmNvbS9tZXRhIiwiaWF0I"
-                "joxNzA2MTkwNzkwfQ.FzvzWyI_CNrLkHhr4oPRQ0XEY8H9DL442QD8tM8dhVM"
-            ):
+            if credentials.credentials != CONFIG.test_token.get_secret_value():
                 credentials_exception.status_code = status.HTTP_403_FORBIDDEN
                 raise credentials_exception
 

--- a/entities_service/service/config.py
+++ b/entities_service/service/config.py
@@ -48,6 +48,20 @@ class ServiceSettings(BaseSettings):
         ),
     ] = True
 
+    test_token: Annotated[
+        SecretStr,
+        Field(
+            description=(
+                "Test token for bypassing OAuth2 authentication and authorization. This should NEVER be "
+                "used in production."
+            )
+        ),
+    ] = SecretStr(
+        "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiJyb290IiwiaXNzIjoiaHR0cDovL29udG8tbnMuY29t"
+        "L21ldGEiLCJleHAiOjE3MDYxOTI1OTAsImNsaWVudF9pZCI6Imh0dHA6Ly9vbnRvLW5zLmNvbS9tZXRhIiwiaWF0I"
+        "joxNzA2MTkwNzkwfQ.FzvzWyI_CNrLkHhr4oPRQ0XEY8H9DL442QD8tM8dhVM"
+    )
+
     # MongoDB backend settings
     mongo_uri: Annotated[
         MongoDsn,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -116,7 +116,7 @@ isort.required-imports = ["from __future__ import annotations"]
 ]
 
 [tool.pytest.ini_options]
-minversion = "7.4"
+minversion = "8.0"
 addopts = "-rs --cov=entities_service --cov-config=pyproject.toml --cov-report=term-missing:skip-covered --no-cov-on-fail"
 filterwarnings = [
     # Treat all warnings as errors


### PR DESCRIPTION
The basic auth users must be created in the 'admin' database (by default it was using the 'test' database).

Furthermore, mongo-express is added as a service for easier access into the content of the test MongoDB.

A `test_token` configuration is also added to be used if `external_oauth` is `False`.

Use Python 3.12 in the Dockerfile as well as in the related CI job.

Remove all instances of `ENTITIES_SERVICE_BASE_URL` (and therefore also `ENTITIES_SERVICE_HOST`) since this is no longer used in any shape or form.

Update dependabot config to also group security updates for Python dependencies.