### PR TITLE
Publish Python package on SINTEF's GitLab

### DIFF
--- a/.github/workflows/cd_release.yml
+++ b/.github/workflows/cd_release.yml
@@ -6,7 +6,7 @@ on:
     - published
 
 jobs:
-  release:
+  build:
     name: External
     uses: SINTEF/ci-cd/.github/workflows/cd_release.yml@v2.8.0
     if: github.repository == 'M-ERA-NET-MEDIATE/ds-entities-service' && startsWith(github.ref, 'refs/tags/v')
@@ -23,11 +23,38 @@ jobs:
       python_version_build: "3.10"
       build_libs: flit
       build_cmd: "flit build"
+      build_dir: "dist"
       changelog_exclude_labels: skip_changelog,duplicate,question,invalid,wontfix
       publish_on_pypi: false
+      upload_distribution: true
 
       # Documentation
       update_docs: false
 
     secrets:
       PAT: ${{ secrets.TEAM40_PAT }}
+
+  publish:
+    name: Publish to SINTEF GitLab
+    needs: build
+    runs-on: ubuntu-latest
+
+    environment:
+      name: GitLab
+      url: ${{ vars.GITLAB_PACKAGE_URL }}
+
+    steps:
+      - name: Download distribution
+        uses: actions/download-artifact@v4
+        with:
+          name: dist  # The artifact will always be called 'dist'
+          path: dist
+
+      - name: Publish to PyPI
+        uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          # The path to the distribution to upload
+          packages-dir: dist
+          repository-url: ${{ vars.GITLAB_PACKAGE_REGISTRY_URL }}
+          user: ${{ secrets.DEPLOY_TOKEN_USERNAME }}
+          password: ${{ secrets.DEPLOY_TOKEN_PASSWORD }}

--- a/.github/workflows/cd_release.yml
+++ b/.github/workflows/cd_release.yml
@@ -12,8 +12,8 @@ jobs:
     if: github.repository == 'M-ERA-NET-MEDIATE/ds-entities-service' && startsWith(github.ref, 'refs/tags/v')
     with:
       # General
-      git_username: "TEAM 4.0[bot]"
-      git_email: "Team4.0@SINTEF.no"
+      git_username: ${{ vars.CI_CD_GIT_USER }}
+      git_email: ${{ vars.CI_CD_GIT_EMAIL }}
       release_branch: main
 
       # Python package
@@ -32,7 +32,7 @@ jobs:
       update_docs: false
 
     secrets:
-      PAT: ${{ secrets.TEAM40_PAT }}
+      PAT: ${{ secrets.SEMANTICMATTER_PAT }}
 
   publish:
     name: Publish to SINTEF GitLab


### PR DESCRIPTION
Update `cd_release.yml` workflow file to publish the built Python package to SINTEF's GitLab instance under the MEDIATE repository.

Closes #29 