### PR TITLE
Exclude `CHANGELOG.md` from relevant pre-commit hooks

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -31,6 +31,7 @@ repos:
       args: ["--pytest-test-first"]
     - id: trailing-whitespace
       args: [--markdown-linebreak-ext=md]
+      exclude: ^CHANGELOG.md$
 
   # Markdown linter to ensure the quality of the documentation
   # More information can be found in its source repository:
@@ -40,7 +41,7 @@ repos:
     hooks:
     - id: markdownlint-cli2
       name: markdownlint
-      # exclude: ^docs/index.md$
+      exclude: ^CHANGELOG.md$
       args:
       - --fix
       - --config=.markdownlint.yaml

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,7 +32,7 @@ dependencies = [
     "pymongo ~=4.6",
     "python-dotenv ~=1.0",
     "pyyaml ~=6.0",
-    "soft7 ~=0.2.0",
+    "soft7 ~=0.2.1",
     "uvicorn >=0.24.0,<1",
 ]
 


### PR DESCRIPTION
Closes #48 

Also, use at minimum v0.2.1 of the `soft7` package.