### PR TITLE
Use fixtures from DataSpaces-Auth

### DIFF
--- a/entities_service/main.py
+++ b/entities_service/main.py
@@ -35,7 +35,7 @@ if bool(int(os.getenv("DS_ENTITIES_SERVICE_DISABLE_AUTH_ROLE_CHECKS", "0"))):
             env_vars_to_unset.add(composed_env_var)
 
         if "url" in env_var:
-            os.environ[composed_env_var] = "http://example.org"
+            os.environ[composed_env_var] = "https://semanticmatter.com"
         else:
             os.environ[composed_env_var] = '["openid","profile","email"]'
 
@@ -60,7 +60,7 @@ if bool(int(os.getenv("DS_ENTITIES_SERVICE_DISABLE_AUTH_ROLE_CHECKS", "0"))):
         },
         # Required fields (for the model)
         preferred_username="test_user",
-        iss="http://example.com",
+        iss="https://semanticmatter.com",
         exp=1234567890,
         aud=["test_client"],
         sub="test_user",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,7 +26,7 @@ requires-python = "~=3.10"
 dynamic = ["version", "description"]
 
 dependencies = [
-    "DataSpaces-Auth~=0.2.1",  # From SINTEF's GitLab (SemanticMatter group)
+    "DataSpaces-Auth~=0.3.0",  # From SINTEF's GitLab (SemanticMatter group)
     "fastapi >=0.114.1,<1",
     "httpx ~=0.27.0",
     "pydantic-settings ~=2.1",
@@ -122,17 +122,6 @@ addopts = "-rs --cov=entities_service --cov-config=pyproject.toml --cov-report=t
 filterwarnings = [
     # Treat all warnings as errors
     "error",
-
-    # Passing app directly to httpx client is deprecated - TestClient still does this
-    "ignore:.*The 'app' shortcut is now deprecated.*:DeprecationWarning",
-
-    # Starlette's TestClient does not properly close all memory streams.
-    # For more information see the discussion on GitHub:
-    # https://github.com/encode/starlette/discussions/2603
-    "ignore:.*MemoryObjectReceiveStream.*:pytest.PytestUnraisableExceptionWarning",
-
-    # DataSpaces-Auth issues a warning if realm-export.json cannot be found
-    "ignore:.*The realm-export\\.json file was not found.*:UserWarning",
 
     # Notice to close MongoClient
     "ignore:.*Unclosed MongoClient opened at.*:ResourceWarning",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,7 +26,7 @@ requires-python = "~=3.10"
 dynamic = ["version", "description"]
 
 dependencies = [
-    "DataSpaces-Auth~=0.1.3",
+    "DataSpaces-Auth~=0.2.0",  # From SINTEF's GitLab (SemanticMatter group)
     "fastapi >=0.114.1,<1",
     "httpx ~=0.27.0",
     "pydantic-settings ~=2.1",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,7 +26,7 @@ requires-python = "~=3.10"
 dynamic = ["version", "description"]
 
 dependencies = [
-    "DataSpaces-Auth~=0.2.0",  # From SINTEF's GitLab (SemanticMatter group)
+    "DataSpaces-Auth~=0.2.1",  # From SINTEF's GitLab (SemanticMatter group)
     "fastapi >=0.114.1,<1",
     "httpx ~=0.27.0",
     "pydantic-settings ~=2.1",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -124,6 +124,11 @@ filterwarnings = [
 
     # Notice to close MongoClient
     "ignore:.*Unclosed MongoClient opened at.*:ResourceWarning",
+
+    # DataSpaces-Auth issues a warning if realm-export.json cannot be found
+    # Keep this only for as long as SemanticMatter/ds-auth#32 is not fixed.
+    # Link: https://github.com/SemanticMatter/ds-auth/issues/32
+    "ignore:.*The realm-export\\.json file was not found.*:UserWarning",
 ]
 
 [tool.coverage.run]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,20 +27,19 @@ dynamic = ["version", "description"]
 
 dependencies = [
     "DataSpaces-Auth~=0.3.0",  # From SINTEF's GitLab (SemanticMatter group)
-    "fastapi >=0.114.1,<1",
+    "fastapi >=0.115.0,<1",
     "httpx ~=0.27.0",
     "pydantic-settings ~=2.1",
     "pymongo ~=4.6",
     "python-dotenv ~=1.0",
     "pyyaml ~=6.0",
     "soft7 ~=0.2.1",
-    "uvicorn >=0.24.0,<1",
+    "uvicorn >=0.31.1,<1",
 ]
 
 [project.optional-dependencies]
 testing = [
-    "dlite-python ~=0.5.16",
-    "numpy <2",  # requirement for DLite v0.5.16, which does not support NumPy v2
+    "dlite-python ~=0.5.22",
     "pytest ~=8.0",
     "pytest-cov ~=5.0",
     "pytest-httpx ~=0.32.0",

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -83,7 +83,8 @@ def pytest_configure(config: pytest.Config) -> None:
     # Avoid raising a user warning in DataSpaces-Auth for not finding 'realm-export.json'
     # Note, this will work as intended once SemanticMatter/ds-auth#32 is fixed.
     # Link: https://github.com/SemanticMatter/ds-auth/issues/32
-    os.environ["DS_AUTH_REALM"] = "test_realm"
+    # This value should be the fallback default value from the DataSpaces-Auth library.
+    os.environ["DS_AUTH_REALM"] = "dataspaces"
 
     # Add extra markers
     config.addinivalue_line(

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -80,6 +80,9 @@ def pytest_configure(config: pytest.Config) -> None:
     os.environ["DS_ENTITIES_SERVICE_X509_CERTIFICATE_FILE"] = "docker_security/test-client.pem"
     os.environ["DS_ENTITIES_SERVICE_CA_FILE"] = "docker_security/test-ca.pem"
 
+    # Avoid raising a user warning in DataSpaces-Auth for not finding 'realm-export.json'
+    os.environ["DS_AUTH_REALM"] = "test_realm"
+
     # Add extra markers
     config.addinivalue_line(
         "markers",

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -81,6 +81,8 @@ def pytest_configure(config: pytest.Config) -> None:
     os.environ["DS_ENTITIES_SERVICE_CA_FILE"] = "docker_security/test-ca.pem"
 
     # Avoid raising a user warning in DataSpaces-Auth for not finding 'realm-export.json'
+    # Note, this will work as intended once SemanticMatter/ds-auth#32 is fixed.
+    # Link: https://github.com/SemanticMatter/ds-auth/issues/32
     os.environ["DS_AUTH_REALM"] = "test_realm"
 
     # Add extra markers

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -7,15 +7,13 @@ from typing import TYPE_CHECKING, NamedTuple
 import pytest
 
 if TYPE_CHECKING:
-    from collections.abc import Callable, Coroutine
     from pathlib import Path
     from typing import Any, Literal, Protocol, TypedDict
 
-    from dataspaces_auth.fastapi._models import TokenData
+    from dataspaces_auth.fastapi._pytest_fixtures import CreateMockValidAccessToken
     from fastapi.testclient import TestClient
     from httpx import Client
 
-    from entities_service.models.auth import DSAPIRole
     from entities_service.service.backend.mongodb import MongoDBBackend
 
     class UserRoleDict(TypedDict):
@@ -60,6 +58,9 @@ class ParameterizeGetEntities(NamedTuple):
 
 
 ## Pytest configuration functions and hooks ##
+
+
+pytest_plugins = ("dataspaces_auth.fastapi._pytest_fixtures",)
 
 
 def pytest_addoption(parser: pytest.Parser) -> None:
@@ -530,67 +531,36 @@ def _mock_lifespan(live_backend: bool, monkeypatch: pytest.MonkeyPatch) -> None:
 
 
 @pytest.fixture
-def client(live_backend: bool) -> ClientFixture:
+def effective_auth_roles() -> dict[str, list[str]]:
+    """Effective roles for the ds-entities-service.
+
+    This overrides the fixture from DataSpaces-Auth.
+
+    These roles are all composite, with the exception of `entities:read`.
+
+    The composite roles are:
+    - `entities:write`
+        Includes: `entities:read`
+    - `entities:edit`
+        Includes: `entities:write` and `entities:read`
+    - `entities:delete`
+        Includes: `entities:edit`, `entities:write`, and `entities:read`
+    - `entities`
+        Includes: `entities:delete`, `entities:edit`, `entities:write`, and `entities:read`
+
+    """
+    return {
+        "entities:read": ["entities:read"],
+        "entities:write": ["entities:write", "entities:read"],
+        "entities:edit": ["entities:edit", "entities:write", "entities:read"],
+        "entities:delete": ["entities:delete", "entities:edit", "entities:write", "entities:read"],
+        "entities": ["entities", "entities:delete", "entities:edit", "entities:write", "entities:read"],
+    }
+
+
+@pytest.fixture
+def client(live_backend: bool, mock_valid_access_token: CreateMockValidAccessToken) -> ClientFixture:
     """Return the test client."""
-    import os
-
-    from fastapi.testclient import TestClient
-    from httpx import Client
-
-    def _create_mock_valid_access_token(
-        allowed_role: DSAPIRole | str,
-    ) -> Callable[[], Coroutine[Any, Any, TokenData]]:
-        """Internal function to create a mock valid_access_token function with a specific set of roles.
-
-        The roles are set by the `allowed_role` parameter and are all composite, with the exception of
-        `entities:read`.
-
-        The composite roles are:
-        - `entities:write`
-          Includes: `entities:read`
-        - `entities:edit`
-          Includes: `entities:write` and `entities:read`
-        - `entities:delete`
-          Includes: `entities:edit`, `entities:write`, and `entities:read`
-        - `entities`
-          Includes: `entities:delete`, `entities:edit`, `entities:write`, and `entities:read`
-
-        """
-        effective_roles: dict[str, list[str]] = {
-            "entities:read": ["entities:read"],
-            "entities:write": ["entities:write", "entities:read"],
-            "entities:edit": ["entities:edit", "entities:write", "entities:read"],
-            "entities:delete": ["entities:delete", "entities:edit", "entities:write", "entities:read"],
-            "entities": ["entities", "entities:delete", "entities:edit", "entities:write", "entities:read"],
-        }
-
-        assert allowed_role in effective_roles, f"Invalid auth role: {allowed_role}"
-
-        async def mock_valid_access_token() -> TokenData:
-            """Mock the valid_access_token function from DataSpaces-Auth.
-
-            Include all available roles for the entities service.
-            """
-            from dataspaces_auth.fastapi._models import TokenData
-
-            return TokenData(
-                # Role mapping
-                resource_access={
-                    "backend": {"roles": effective_roles[allowed_role]},
-                    # Required resource_access field (for the model)
-                    "account": {"roles": []},
-                },
-                # Required fields (for the model)
-                preferred_username="test_user",
-                iss="http://example.com",
-                exp=1234567890,
-                aud=["test_client"],
-                sub="test_user",
-                iat=1234567890,
-                jti="test_jti",
-            )
-
-        return mock_valid_access_token
 
     def _client(
         raise_server_exceptions: bool = True,
@@ -602,19 +572,24 @@ def client(live_backend: bool) -> ClientFixture:
         """Return the test client with the given authentication role."""
         if not live_backend:
             from dataspaces_auth.fastapi import valid_access_token
+            from fastapi.testclient import TestClient
 
             from entities_service.main import APP
 
             # "entities:read" is the default role given to all users
             allowed_role = allowed_role or "entities:read"
 
-            APP.dependency_overrides[valid_access_token] = _create_mock_valid_access_token(allowed_role)
+            APP.dependency_overrides[valid_access_token] = mock_valid_access_token(allowed_role)
 
             return TestClient(
                 app=APP,
                 raise_server_exceptions=raise_server_exceptions,
                 follow_redirects=True,
             )
+
+        import os
+
+        from httpx import Client
 
         port = os.getenv("DS_ENTITIES_SERVICE_PORT", "7000")
 

--- a/tests/service/routers/conftest.py
+++ b/tests/service/routers/conftest.py
@@ -13,7 +13,6 @@ if TYPE_CHECKING:
     from typing import Any
 
     from pydantic import AnyHttpUrl
-    from pytest_httpx import HTTPXMock
     from s7 import SOFT7Entity
 
 
@@ -210,27 +209,3 @@ def _mock_backend(
             return len(self.__test_data)
 
     monkeypatch.setattr("entities_service.service.backend.mongodb.MongoDBBackend", MockBackend)
-
-
-@pytest.fixture(autouse=True)
-def _set_ds_auth_required_settings(
-    monkeypatch: pytest.MonkeyPatch, httpx_mock: HTTPXMock, caplog: pytest.LogCaptureFixture
-) -> None:
-    """Set the required settings for DataSpaces-Auth."""
-    # Required settings for DataSpaces-Auth
-    monkeypatch.setenv("DS_AUTH_AUTHORIZATION_URL", "http://example.com/auth")
-    monkeypatch.setenv("DS_AUTH_TOKEN_URL", "http://example.com/token")
-    monkeypatch.setenv("DS_AUTH_CERTS_URL", "http://example.com/certs")
-    monkeypatch.setenv("DS_AUTH_SCOPES", '["openid","profile","email"]')
-
-    # Mock call to OpenID configuration URL
-    mock_openid_config_url = "http://example.com/test-realm/.well-known/openid-configuration"
-    monkeypatch.setenv("DS_AUTH_OPENID_CONFIG_URL", mock_openid_config_url)
-    httpx_mock.add_response(
-        url=mock_openid_config_url,
-        status_code=404,
-        text="Testing",
-    )
-
-    # Ignore error log from "failing to get OpenID configuration" in DataSpaces-Auth
-    caplog.set_level(100, logger="dataspaces_auth.fastapi._settings")

--- a/tests/service/routers/test_entities_get.py
+++ b/tests/service/routers/test_entities_get.py
@@ -9,7 +9,10 @@ import pytest
 if TYPE_CHECKING:
     from ...conftest import ClientFixture, ParameterizeGetEntities
 
-pytestmark = pytest.mark.httpx_mock(assert_all_responses_were_requested=False)
+pytestmark = [
+    pytest.mark.usefixtures("_mock_openid_url_request"),
+    pytest.mark.httpx_mock(can_send_already_matched_responses=True),
+]
 
 ENDPOINT = "/entities"
 

--- a/tests/service/routers/test_entities_post.py
+++ b/tests/service/routers/test_entities_post.py
@@ -14,9 +14,8 @@ if TYPE_CHECKING:
 
 
 pytestmark = [
-    pytest.mark.usefixtures("_empty_backend_collection"),
+    pytest.mark.usefixtures("_empty_backend_collection", "_mock_openid_url_request"),
     pytest.mark.httpx_mock(can_send_already_matched_responses=True),
-    pytest.mark.httpx_mock(assert_all_responses_were_requested=False),
 ]
 
 


### PR DESCRIPTION
Utilize the exposed fixtures in the upcoming DataSpaces-Auth release.

This is a draft until a new release of DataSpaces-Auth has happened, which includes SemanticMatter/ds-auth#18.
**Edit**: This has now happened. [v0.2.0](https://github.com/SemanticMatter/ds-auth/releases/tag/v0.2.0) has been released.

~This should be rebased after #59 is merged~ Done.

Another PR should be opened once SemanticMatter/ds-auth#19 has been merged and released in a new DataSpaces-Auth version. This is now expressed via issue #63.
**Edit**: This has now happened, the newest version is v0.2.1.
**Edit**: Updated to the newest version: v0.3.0.

Cleaned up ignored warnings for the test suite.

<details closed>
<summary>Summary from Copilot</summary>
</br>
This pull request includes several updates to the `entities_service` to improve logging, dependency management, and testing configurations. The most important changes include updating the logger configuration, modifying environment variable handling for testing, updating dependencies, and refining test fixtures.

### Logger Configuration:
* Changed the logger initialization to use `__name__` instead of a hardcoded string in `entities_service/main.py`.

### Environment Variable Handling:
* Removed the manual setup and cleanup of environment variables for testing in `entities_service/main.py`. [[1]](diffhunk://#diff-de2ee486a7e431227cc1661c1a7279de8ee28190053d6c00559bc3880dd295cdL17-R28) [[2]](diffhunk://#diff-de2ee486a7e431227cc1661c1a7279de8ee28190053d6c00559bc3880dd295cdL94-L112)

### Dependency Updates:
* Updated dependencies in `pyproject.toml` to newer versions, including `DataSpaces-Auth` and `fastapi`.
* Updated test dependencies and removed deprecated warnings.

### Test Fixtures:
* Refined test fixtures to use `dataspaces_auth.fastapi._pytest_fixtures` and updated role handling in `tests/conftest.py`. [[1]](diffhunk://#diff-e52e4ddd58b7ef887ab03c04116e676f6280b824ab7469d5d3080e5cba4f2128L10-R13) [[2]](diffhunk://#diff-e52e4ddd58b7ef887ab03c04116e676f6280b824ab7469d5d3080e5cba4f2128L40-R39) [[3]](diffhunk://#diff-e52e4ddd58b7ef887ab03c04116e676f6280b824ab7469d5d3080e5cba4f2128R61-R63) [[4]](diffhunk://#diff-e52e4ddd58b7ef887ab03c04116e676f6280b824ab7469d5d3080e5cba4f2128R83-R88) [[5]](diffhunk://#diff-e52e4ddd58b7ef887ab03c04116e676f6280b824ab7469d5d3080e5cba4f2128L533-R544)
* Added a new fixture to avoid raising a user warning for missing `realm-export.json`.

### Test Configuration:
* Updated test configuration to use new fixtures and removed unnecessary setup in `tests/service/routers/conftest.py`. [[1]](diffhunk://#diff-57f42a93a910d87e53d9b0c9137068354bf18b40203e5c0fd1ea59d1159adcc3L16) [[2]](diffhunk://#diff-57f42a93a910d87e53d9b0c9137068354bf18b40203e5c0fd1ea59d1159adcc3L213-L236)
* Modified test files to use the new `_mock_openid_url_request` fixture. [[1]](diffhunk://#diff-407bf358bfd6bcf2435e6e903f57104df46d36d98b2d234af1acc55839042fdeL12-R15) [[2]](diffhunk://#diff-1770f9e122ba693d491055cb08c2a8e03e0e4e77fdf4de0945d73831021482c0L17-R17)
</details>