### PR TITLE
Use SOFT7IdentityURI and type from s7

### DIFF
--- a/dataspaces_entities/backend/backend.py
+++ b/dataspaces_entities/backend/backend.py
@@ -15,7 +15,7 @@ if TYPE_CHECKING:  # pragma: no cover
     from collections.abc import Generator, Iterator
     from typing import Any
 
-    from pydantic import AnyHttpUrl
+    from s7.pydantic_models.soft7_entity import SOFT7IdentityURIType
 
 
 LOGGER = logging.getLogger(__name__)
@@ -121,21 +121,23 @@ class Backend(ABC):
         raise NotImplementedError
 
     @abstractmethod
-    def read(self, entity_identity: AnyHttpUrl | str) -> dict[str, Any] | None:  # pragma: no cover
+    def read(
+        self, entity_identity: SOFT7IdentityURIType | str
+    ) -> dict[str, Any] | None:  # pragma: no cover
         """Read an entity from the backend."""
         raise NotImplementedError
 
     @abstractmethod
     def update(
         self,
-        entity_identity: AnyHttpUrl | str,
+        entity_identity: SOFT7IdentityURIType | str,
         entity: SOFT7Entity | dict[str, Any],
     ) -> None:  # pragma: no cover
         """Update an entity in the backend."""
         raise NotImplementedError
 
     @abstractmethod
-    def delete(self, entity_identities: Iterable[AnyHttpUrl | str]) -> None:  # pragma: no cover
+    def delete(self, entity_identities: Iterable[SOFT7IdentityURIType | str]) -> None:  # pragma: no cover
         """Delete one or more entities in the backend."""
         raise NotImplementedError
 

--- a/dataspaces_entities/models/__init__.py
+++ b/dataspaces_entities/models/__init__.py
@@ -2,12 +2,7 @@
 
 from __future__ import annotations
 
-import re
-
 from .auth import DSAPIRole
 from .service_errors import HTTPError
 
-URI_REGEX = re.compile(r"^(?P<namespace>https?://.+)/(?P<version>\d(?:\.\d+){0,2})/(?P<name>[^/#?]+)$")
-"""Regular expression to parse a SOFT entity URI."""
-
-__all__ = ("URI_REGEX", "DSAPIRole", "HTTPError")
+__all__ = ("DSAPIRole", "HTTPError")

--- a/tests/backend/test_mongodb.py
+++ b/tests/backend/test_mongodb.py
@@ -109,8 +109,9 @@ def test_update(parameterized_entity: ParameterizeGetEntities) -> None:
     """Test the update method."""
     from copy import deepcopy
 
+    from s7.pydantic_models.soft7_entity import SOFT7IdentityURI, parse_identity
+
     from dataspaces_entities.backend import get_backend
-    from dataspaces_entities.backend.mongodb import URI_REGEX
 
     backend = get_backend()
 
@@ -138,11 +139,13 @@ def test_update(parameterized_entity: ParameterizeGetEntities) -> None:
     # Apply the change
     backend.update(parameterized_entity.identity, changed_raw_entity)
 
+    namespace, version, name = parse_identity(SOFT7IdentityURI(parameterized_entity.identity))
+
     # Retrieve the entity again
     entity_from_backend = backend._collection.find_one(
         {
             "$or": [
-                URI_REGEX.match(parameterized_entity.identity).groupdict(),
+                {"namespace": namespace, "version": version, "name": name},
                 {"identity": parameterized_entity.identity},
             ]
         },
@@ -156,16 +159,20 @@ def test_update(parameterized_entity: ParameterizeGetEntities) -> None:
 
 def test_delete(parameterized_entity: ParameterizeGetEntities) -> None:
     """Test the delete method."""
+
+    from s7.pydantic_models.soft7_entity import SOFT7IdentityURI, parse_identity
+
     from dataspaces_entities.backend import get_backend
-    from dataspaces_entities.backend.mongodb import URI_REGEX
 
     backend = get_backend()
+
+    namespace, version, name = parse_identity(SOFT7IdentityURI(parameterized_entity.identity))
 
     # Ensure the entity currently exists in the backend
     entity_from_backend = backend._collection.find_one(
         {
             "$or": [
-                URI_REGEX.match(parameterized_entity.identity).groupdict(),
+                {"namespace": namespace, "version": version, "name": name},
                 {"identity": parameterized_entity.identity},
             ]
         },
@@ -185,7 +192,7 @@ def test_delete(parameterized_entity: ParameterizeGetEntities) -> None:
     entity_from_backend = backend._collection.find_one(
         {
             "$or": [
-                URI_REGEX.match(parameterized_entity.identity).groupdict(),
+                {"namespace": namespace, "version": version, "name": name},
                 {"identity": parameterized_entity.identity},
             ]
         },
@@ -201,17 +208,20 @@ def test_search(parameterized_entity: ParameterizeGetEntities) -> None:
 
     Note, this method only accepts valid MongoDB queries.
     """
+    from s7.pydantic_models.soft7_entity import SOFT7IdentityURI, parse_identity
+
     from dataspaces_entities.backend import get_backend
-    from dataspaces_entities.backend.mongodb import URI_REGEX
 
     backend = get_backend()
+
+    namespace, version, name = parse_identity(SOFT7IdentityURI(parameterized_entity.identity))
 
     # Search for the entity
     entities_from_backend = list(
         backend.search(
             {
                 "$or": [
-                    URI_REGEX.match(parameterized_entity.identity).groupdict(),
+                    {"namespace": namespace, "version": version, "name": name},
                     {"identity": parameterized_entity.identity},
                 ]
             }
@@ -232,8 +242,9 @@ def test_search(parameterized_entity: ParameterizeGetEntities) -> None:
 
 def test_count(parameterized_entity: ParameterizeGetEntities) -> None:
     """Test the count method."""
+    from s7.pydantic_models.soft7_entity import SOFT7IdentityURI, parse_identity
+
     from dataspaces_entities.backend import get_backend
-    from dataspaces_entities.backend.mongodb import URI_REGEX
 
     backend = get_backend()
 
@@ -241,12 +252,14 @@ def test_count(parameterized_entity: ParameterizeGetEntities) -> None:
     number_of_entities = len(backend)
     assert backend.count({}) == number_of_entities
 
+    namespace, version, name = parse_identity(SOFT7IdentityURI(parameterized_entity.identity))
+
     # Count the entity
     assert (
         backend.count(
             {
                 "$or": [
-                    URI_REGEX.match(parameterized_entity.identity).groupdict(),
+                    {"namespace": namespace, "version": version, "name": name},
                     {"identity": parameterized_entity.identity},
                 ]
             }

--- a/tests/backend/test_mongodb.py
+++ b/tests/backend/test_mongodb.py
@@ -145,7 +145,7 @@ def test_update(parameterized_entity: ParameterizeGetEntities) -> None:
     entity_from_backend = backend._collection.find_one(
         {
             "$or": [
-                {"namespace": namespace, "version": version, "name": name},
+                {"namespace": str(namespace), "version": version, "name": name},
                 {"identity": parameterized_entity.identity},
             ]
         },
@@ -172,7 +172,7 @@ def test_delete(parameterized_entity: ParameterizeGetEntities) -> None:
     entity_from_backend = backend._collection.find_one(
         {
             "$or": [
-                {"namespace": namespace, "version": version, "name": name},
+                {"namespace": str(namespace), "version": version, "name": name},
                 {"identity": parameterized_entity.identity},
             ]
         },
@@ -192,7 +192,7 @@ def test_delete(parameterized_entity: ParameterizeGetEntities) -> None:
     entity_from_backend = backend._collection.find_one(
         {
             "$or": [
-                {"namespace": namespace, "version": version, "name": name},
+                {"namespace": str(namespace), "version": version, "name": name},
                 {"identity": parameterized_entity.identity},
             ]
         },
@@ -221,7 +221,7 @@ def test_search(parameterized_entity: ParameterizeGetEntities) -> None:
         backend.search(
             {
                 "$or": [
-                    {"namespace": namespace, "version": version, "name": name},
+                    {"namespace": str(namespace), "version": version, "name": name},
                     {"identity": parameterized_entity.identity},
                 ]
             }
@@ -259,7 +259,7 @@ def test_count(parameterized_entity: ParameterizeGetEntities) -> None:
         backend.count(
             {
                 "$or": [
-                    {"namespace": namespace, "version": version, "name": name},
+                    {"namespace": str(namespace), "version": version, "name": name},
                     {"identity": parameterized_entity.identity},
                 ]
             }

--- a/tests/routers/test_entities_get.py
+++ b/tests/routers/test_entities_get.py
@@ -98,15 +98,16 @@ def test_get_entity_invalid_identity(client: ClientFixture) -> None:
     """Test that the service raises a pydantic ValidationError and returns an
     Unprocessable Entity (422) for invalid identities.
 
-    Test by reversing version and name in identity, thereby making it invalid.
+    Test by providing a non URL URI/IRI, i.e., a string that is not a URL.
+    Here we will test with a UUID as string.
     """
     import json
+    from uuid import uuid4
 
     from fastapi import status
 
-    namespace, version, name = "http://onto-ns.com/meta", "1.0", "EntityName"
     with client() as client_:
-        response = client_.get(ENDPOINT, params={"id": [f"{namespace}/{name}/{version}"]})
+        response = client_.get(ENDPOINT, params={"id": [str(uuid4())]})
 
     try:
         response_json = response.json()


### PR DESCRIPTION
This removes the use of the much stricter regular expression enforcing a URL of the form `<namespace>/<version>/<name>` as URI and instead uses the `SOFT7IdentityURI` and `SOFT7IdentityURIType` from `s7.pydantic_models.soft7_entity`.

While this type is currently also constrained to having the URI be a URL (only allowing the `http`, `https`, and `file` schemes), it is a much looser constraint, and furthermore, consistent with other parts of the `s7` package.

As a bonus - should the `SOFT7IdentityURI` and its corresponding type be updated to allow other forms of URIs than URLs, this should automatically be reflected here - although minor updates and changes (especially to the unit tests) may be in order.