### PR TITLE
Drop safety in favor of pip-audit

### DIFF
--- a/.github/workflows/ci_tests.yml
+++ b/.github/workflows/ci_tests.yml
@@ -23,17 +23,8 @@ jobs:
       run_pre-commit: false
 
       # pylint & safety
-      python_version_pylint_safety: "3.10"
-      pip_index_url_pylint_safety: "${{ vars.EXTERNAL_PYPI_INDEX_URL }}"
       run_pylint: false
-
-      run_safety: true
-      # ID: 70612
-      #   Package: Jinja2
-      #   Has been disputed by the maintainer and multiple third parties.
-      #   For more information see: https://github.com/advisories/GHSA-f6pv-j8mr-w6rr
-      safety_options: |
-        --ignore=70612
+      run_safety: false
 
       # Build dist
       python_version_package: "3.10"
@@ -42,6 +33,28 @@ jobs:
 
       # Build documentation
       run_build_docs: false
+
+  pip-audit:
+    name: pip-audit
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout ${{ github.repository }}
+        uses: actions/checkout@v4
+
+      - name: Setup Python 3.10
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.10"
+
+      - name: Install pip-audit
+        run: |
+          python -m pip install -U pip
+          pip install -U setuptools wheel
+          pip install -e .[dev,server]
+
+      - name: Run pip-audit
+        uses: pypa/gh-action-pip-audit@v1.1.0
 
   docker:
     name: Docker

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -47,10 +47,10 @@ RUN --mount=type=bind,source=docker/requirements_development.txt,target=/tmp/req
 # Run static security check and linters
 RUN --mount=type=bind,source=docker/.pre-commit-config_docker.yaml,target=/app/.pre-commit-config.yaml \
     --mount=type=bind,source=pyproject.toml,target=/app/pyproject.toml \
-    --mount=type=cache,target=${HOME}/.cache/pre-commit \
-    git init && git add . && /tmp/dev_venv/bin/pre-commit run --all-files || ( cat ${HOME}/.cache/pre-commit/pre-commit.log && exit 1 )
+    --mount=type=cache,target=~/.cache/pre-commit \
+    git init && git add . && /tmp/dev_venv/bin/pre-commit run --all-files || ( cat ~/.cache/pre-commit/pre-commit.log && exit 1 )
 RUN --mount=type=bind,source=docker/pyproject_requirements.txt,target=/tmp/requirements.txt \
-    /tmp/dev_venv/bin/safety check -r /tmp/requirements.txt --full-report
+    /tmp/dev_venv/bin/pip-audit -r /tmp/requirements.txt --desc on
 
 # Clean up
 RUN rm -rf ${HOME}/.cache /tmp/* /app/.git && pip cache purge

--- a/docker/pyproject_requirements.txt
+++ b/docker/pyproject_requirements.txt
@@ -1,4 +1,4 @@
-# This file is here to "safety check" all the dependencies listed in pyproject.toml
+# This file is here to "pip-audit" all the dependencies listed in pyproject.toml
 --index-url "https://gitlab.sintef.no/api/v4/projects/17883/packages/pypi/simple"
 DataSpaces-Auth[fastapi]~=0.3.1
 fastapi>=0.115.5,<1

--- a/docker/requirements_development.txt
+++ b/docker/requirements_development.txt
@@ -1,2 +1,2 @@
+pip-audit~=2.9
 pre-commit~=4.2
-safety~=3.3


### PR DESCRIPTION
This has been done for both CI and the "development" Dockerfile target.

## AI Summary

This pull request replaces the use of `safety` with `pip-audit` for dependency vulnerability checks across the CI workflows and Docker setup. The changes involve updating configurations, workflows, and dependency files to reflect this transition.

### CI Workflow Updates:
* [`.github/workflows/ci_tests.yml`](diffhunk://#diff-bf607a21ebbd18b3f436cc9fac6937d9c8839c33ae022cb29c2bddd873f470ebL26-R27): Disabled `safety` in the existing CI workflow and introduced a new `pip-audit` job to perform dependency vulnerability checks using the `pypa/gh-action-pip-audit` GitHub Action. [[1]](diffhunk://#diff-bf607a21ebbd18b3f436cc9fac6937d9c8839c33ae022cb29c2bddd873f470ebL26-R27) [[2]](diffhunk://#diff-bf607a21ebbd18b3f436cc9fac6937d9c8839c33ae022cb29c2bddd873f470ebR37-R58)

### Docker Configuration Updates:
* [`docker/Dockerfile`](diffhunk://#diff-f34da55ca08f1a30591d8b0b3e885bcc678537b2a9a4aadea4f190806b374ddcL50-R53): Replaced the `safety check` command with `pip-audit` for auditing dependencies in the Dockerfile. Updated the cache directory path for consistency.

### Dependency File Updates:
* [`docker/pyproject_requirements.txt`](diffhunk://#diff-22d33a855339dcd882ce93a56e877cda160ae494bcdc67d4508e80b162b6c086L1-R1): Updated the comment to reflect the use of `pip-audit` instead of `safety`.
* [`docker/requirements_development.txt`](diffhunk://#diff-65b34689c752bdb43a75d8e064f731df67620b069432dade4e3301ab0b8668ccR1-L2): Removed `safety` and added `pip-audit` as a dependency.