### PR TITLE
Update to latest DLite-Python

### DIFF
--- a/docker/pyproject_requirements.txt
+++ b/docker/pyproject_requirements.txt
@@ -2,7 +2,7 @@
 --index-url "https://gitlab.sintef.no/api/v4/projects/17883/packages/pypi/simple"
 DataSpaces-Auth[fastapi]~=0.3.1
 fastapi>=0.115.5,<1
-httpx>=0.27.2,<1
+httpx~=0.28.1
 pydantic-settings~=2.9
 pymongo~=4.12
 python-dotenv~=1.1
@@ -11,7 +11,7 @@ soft7>=0.3.0,<1
 uvicorn-worker>=0.3.0,<1
 
 # 'testing' extra
-dlite-python<=0.5.23; python_version<'3.13'
+dlite-python~=0.5.29
 pytest~=8.3
 pytest-cov~=6.1
 pytest-httpx~=0.35.0

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -43,7 +43,7 @@ dynamic = ["version", "description"]
 dependencies = [
     "DataSpaces-Auth[fastapi] ~=0.3.1",  # From SINTEF's GitLab (SemanticMatter group)
     "fastapi >=0.115.5,<1",
-    "httpx >=0.27.2,<1",  # Support on v0.27 for the
+    "httpx ~=0.28.1",
     "pydantic-settings ~=2.9",
     "pymongo ~=4.12",
     "python-dotenv ~=1.1",
@@ -54,8 +54,7 @@ dependencies = [
 
 [project.optional-dependencies]
 testing = [
-    # Pytest runs, end in Segmentation Fault for dlite-python versions >0.5.23
-    "dlite-python <=0.5.23; python_version<'3.13'",  # DLite is not yet compatible with Python 3.13
+    "dlite-python ~=0.5.29",
     "pytest ~=8.3",
     "pytest-cov ~=6.1",
     "pytest-httpx ~=0.35.0",
@@ -145,6 +144,9 @@ filterwarnings = [
     # Keep this only for as long as SemanticMatter/ds-auth#32 is not fixed.
     # Link: https://github.com/SemanticMatter/ds-auth/issues/32
     "ignore:.*The realm-export\\.json file was not found.*:UserWarning",
+
+    # Avoid SegmentationFault from DLite
+    "ignore::DeprecationWarning:dlite",
 ]
 
 [tool.coverage.run]

--- a/tests/routers/test_entities_get.py
+++ b/tests/routers/test_entities_get.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations
 
-import sys
 from typing import TYPE_CHECKING
 
 import pytest
@@ -43,7 +42,6 @@ def test_get_entity(
     assert resolved_entity == parameterized_entity.parsed_entity, json.dumps(resolved_entity, indent=2)
 
 
-@pytest.mark.skipif(sys.version_info >= (3, 13), reason="DLite does not support Python 3.13+")
 def test_get_entity_instance(
     parameterized_entity: ParameterizeGetEntities,
     client: ClientFixture,


### PR DESCRIPTION
Note, all DeprecationWarnings are ignored from dlite during testing to avoid SegmentationFault.

## AI Summary

This pull request updates dependencies, improves compatibility, and removes redundant code. The most critical changes involve updating library versions in `pyproject.toml` and `docker/pyproject_requirements.txt`, addressing Python 3.13 compatibility issues, and cleaning up unused imports and decorators in test files.

### Dependency Updates:
* Updated `httpx` to `~=0.28.1` in both `docker/pyproject_requirements.txt` and `pyproject.toml` to ensure compatibility with newer features and bug fixes. [[1]](diffhunk://#diff-22d33a855339dcd882ce93a56e877cda160ae494bcdc67d4508e80b162b6c086L5-R5) [[2]](diffhunk://#diff-50c86b7ed8ac2cf95bd48334961bf0530cdc77b5a56f852c5c61b89d735fd711L46-R46)
* Updated `dlite-python` to `~=0.5.29` and removed the Python 3.13 version constraint, reflecting improved compatibility in the latest version. [[1]](diffhunk://#diff-22d33a855339dcd882ce93a56e877cda160ae494bcdc67d4508e80b162b6c086L14-R14) [[2]](diffhunk://#diff-50c86b7ed8ac2cf95bd48334961bf0530cdc77b5a56f852c5c61b89d735fd711L57-R57)

### Compatibility Improvements:
* Added a new warning filter for `DeprecationWarning` related to `dlite`, to avoid segmentation faults during testing.

### Code Cleanup:
* Removed the unused `sys` import from `tests/routers/test_entities_get.py`.
* Removed the `@pytest.mark.skipif` decorator from a test case, as the Python 3.13 compatibility issue with `dlite-python` has been resolved.