### PR TITLE
Fix typo

### DIFF
--- a/dataspaces_entities/main.py
+++ b/dataspaces_entities/main.py
@@ -58,7 +58,7 @@ async def lifespan(app: FastAPI):  # noqa: ARG001
     """Add lifespan events to the application."""
     config = get_config()
 
-    LOGGER.debug("DataSpaces Entities Services configuration: %s", config)
+    LOGGER.debug("DataSpaces-Entities configuration: %s", config)
 
     # Initialize backend
     get_backend(config.backend).initialize()

--- a/dataspaces_entities/main.py
+++ b/dataspaces_entities/main.py
@@ -58,7 +58,7 @@ async def lifespan(app: FastAPI):  # noqa: ARG001
     """Add lifespan events to the application."""
     config = get_config()
 
-    LOGGER.debug("DataSpaces-Graphs configuration: %s", config)
+    LOGGER.debug("DataSpaces Entities Services configuration: %s", config)
 
     # Initialize backend
     get_backend(config.backend).initialize()


### PR DESCRIPTION
Very minor fix.

Thought `DS_ENTITIES_EXTERNAL_OAUTH` was still a thing, but it seems not - so this PR has become much smaller than intended.

## AI Summary

This pull request updates a log message in the application startup sequence to clarify which service's configuration is being logged.

- Logging improvements:
  * [`dataspaces_entities/main.py`](diffhunk://#diff-b82b283880008da66b32d19505810038270fa29dbb36b47baac6d3e9dae5480dL61-R61): Updated the debug log message in the `lifespan` function to specify "DataSpaces Entities Services configuration" instead of the previous, less specific message.